### PR TITLE
V0.1.0

### DIFF
--- a/wikilabs/tocP/plugin.info
+++ b/wikilabs/tocP/plugin.info
@@ -3,6 +3,6 @@
 	"description": "Table of Contents - parent field based",
 	"author": "Mario Pietsch",
 	"core-version": ">=5.1.13",
-	"version": "0.0.2",
+	"version": "0.1.0",
 	"list": "readme license"
 }

--- a/wikilabs/tocP/tiddlers/$__plugins_wikilabs_tocP_Stylesheet.tid
+++ b/wikilabs/tocP/tiddlers/$__plugins_wikilabs_tocP_Stylesheet.tid
@@ -7,3 +7,7 @@ type: text/css
 .tc-tabbed-table-of-contents .wltc-btn-new-child {
   display: none;
 }
+
+.tocp .tc-tiddlylink {
+  color: green;
+}

--- a/wikilabs/tocP/tiddlers/$__plugins_wikilabs_tocP_macros.tid
+++ b/wikilabs/tocP/tiddlers/$__plugins_wikilabs_tocP_macros.tid
@@ -7,7 +7,7 @@ type: text/vnd.tiddlywiki
 \define tocP-caption()
 <$set name="tv-wikilinks" value="no">
   <$transclude field="caption">
-    <$view field="title"/>
+    <span title={{!!tooltip}}><$view field="title"/></span>
   </$transclude>
 </$set>
 \end
@@ -16,9 +16,9 @@ type: text/vnd.tiddlywiki
 <ol class="tc-toc">
   <$list filter="""[has[$field$]$field$[$tag$]!has[draft.of]$sort$] $exclude$""">
     <$vars item=<<currentTiddler>> path="""$path$/$tag$""" excluded="""$exclude$ -[[$tag$]]""" field="""$field$""">
-      <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" value="toc-item-selected">
+      <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item">
         <li class=<<toc-item-class>>>
-          <$list filter="[all[current]toc-link[no]]" emptyMessage="<$link><$view field='caption'><$view field='title'/></$view></$link>">
+          <$list filter="[all[current]toc-link[no]]" emptyMessage="<$link tooltip={{!!tooltip}}><$view field='caption'><$view field='title'/></$view></$link>">
             <<tocP-caption>>
           </$list>
           <$transclude tiddler='$:/config/wikilabs/tocP/newChild'></$transclude>
@@ -37,7 +37,7 @@ type: text/vnd.tiddlywiki
 \define tocP-linked-expandable-body(tag,sort:"",itemClassFilter,exclude,path,field:"parent")
 <!-- helper function -->
 <$set name="toc-state" value=<<qualify """$:/state/toc$path$-$(currentTiddler)$""">>>
-  <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" value="toc-item-selected">
+  <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" >
     <li class=<<toc-item-class>>>
     <$link>
       <$reveal type="nomatch" state=<<toc-state>> text="open">
@@ -64,7 +64,7 @@ type: text/vnd.tiddlywiki
 \define tocP-unlinked-expandable-body(tag,sort:"",itemClassFilter:" ",exclude,path,field:"parent")
 <!-- helper function -->
 <$set name="toc-state" value=<<qualify """$:/state/toc$path$-$(currentTiddler)$""">>>
-  <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" value="toc-item-selected">
+  <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" >
     <li class=<<toc-item-class>>>
       <$reveal type="nomatch" state=<<toc-state>> text="open">
         <$button set=<<toc-state>> setTo="open" class="tc-btn-invisible">
@@ -105,7 +105,7 @@ type: text/vnd.tiddlywiki
 
 \define tocP-linked-selective-expandable-body(tag,sort:"",itemClassFilter:" ",exclude,path,field:"parent")
 <$set name="toc-state" value=<<qualify """$:/state/toc$path$-$(currentTiddler)$""">>>
-  <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" value="toc-item-selected" >
+  <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" >
     <li class=<<toc-item-class>>>
       <$link>
           <$list filter="""[has[$field$]$field$<currentTiddler>limit[1]]""" variable="ignore" emptyMessage="<$button class='tc-btn-invisible'>{{$:/core/images/blank}}</$button>">
@@ -133,7 +133,7 @@ type: text/vnd.tiddlywiki
 
 \define tocP-unlinked-selective-expandable-body(tag,sort:"",itemClassFilter:" ",exclude,path,field:"parent")
 <$set name="toc-state" value=<<qualify """$:/state/toc$path$-$(currentTiddler)$""">>>
-  <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" value="toc-item-selected">
+  <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" >
     <li class=<<toc-item-class>>>
       <$list filter="""[has[$field$]$field$<currentTiddler>limit[1]]""" variable="ignore" emptyMessage="<$button class='tc-btn-invisible'>{{$:/core/images/blank}}</$button> <$view field='caption'><$view field='title'/></$view>">
         <$reveal type="nomatch" state=<<toc-state>> text="open">

--- a/wikilabs/tocP/tiddlers/$__plugins_wikilabs_tocP_macros.tid
+++ b/wikilabs/tocP/tiddlers/$__plugins_wikilabs_tocP_macros.tid
@@ -16,7 +16,7 @@ type: text/vnd.tiddlywiki
 <ol class="tc-toc">
   <$list filter="""[has[$field$]$field$[$tag$]!has[draft.of]$sort$] $exclude$""">
     <$vars item=<<currentTiddler>> path="""$path$/$tag$""" excluded="""$exclude$ -[[$tag$]]""" field="""$field$""">
-      <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item">
+      <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" value="toc-item-selected">
         <li class=<<toc-item-class>>>
           <$list filter="[all[current]toc-link[no]]" emptyMessage="<$link tooltip={{!!tooltip}}><$view field='caption'><$view field='title'/></$view></$link>">
             <<tocP-caption>>
@@ -37,7 +37,7 @@ type: text/vnd.tiddlywiki
 \define tocP-linked-expandable-body(tag,sort:"",itemClassFilter,exclude,path,field:"parent")
 <!-- helper function -->
 <$set name="toc-state" value=<<qualify """$:/state/toc$path$-$(currentTiddler)$""">>>
-  <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" >
+  <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" value="toc-item-selected">
     <li class=<<toc-item-class>>>
     <$link>
       <$reveal type="nomatch" state=<<toc-state>> text="open">
@@ -64,16 +64,16 @@ type: text/vnd.tiddlywiki
 \define tocP-unlinked-expandable-body(tag,sort:"",itemClassFilter:" ",exclude,path,field:"parent")
 <!-- helper function -->
 <$set name="toc-state" value=<<qualify """$:/state/toc$path$-$(currentTiddler)$""">>>
-  <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" >
+  <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" value="toc-item-selected">
     <li class=<<toc-item-class>>>
       <$reveal type="nomatch" state=<<toc-state>> text="open">
-        <$button set=<<toc-state>> setTo="open" class="tc-btn-invisible">
+        <$button set=<<toc-state>> setTo="open" class="tc-btn-invisible" tooltip={{!!tooltip}}>
           {{$:/core/images/right-arrow}}
           <<tocP-caption>>
         </$button>
       </$reveal>
       <$reveal type="match" state=<<toc-state>> text="open">
-        <$button set=<<toc-state>> setTo="close" class="tc-btn-invisible">
+        <$button set=<<toc-state>> setTo="close" class="tc-btn-invisible" tooltip={{!!tooltip}}>
           {{$:/core/images/down-arrow}}
           <<tocP-caption>>
         </$button>
@@ -105,7 +105,7 @@ type: text/vnd.tiddlywiki
 
 \define tocP-linked-selective-expandable-body(tag,sort:"",itemClassFilter:" ",exclude,path,field:"parent")
 <$set name="toc-state" value=<<qualify """$:/state/toc$path$-$(currentTiddler)$""">>>
-  <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" >
+  <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" value="toc-item-selected">
     <li class=<<toc-item-class>>>
       <$link>
           <$list filter="""[has[$field$]$field$<currentTiddler>limit[1]]""" variable="ignore" emptyMessage="<$button class='tc-btn-invisible'>{{$:/core/images/blank}}</$button>">
@@ -133,17 +133,17 @@ type: text/vnd.tiddlywiki
 
 \define tocP-unlinked-selective-expandable-body(tag,sort:"",itemClassFilter:" ",exclude,path,field:"parent")
 <$set name="toc-state" value=<<qualify """$:/state/toc$path$-$(currentTiddler)$""">>>
-  <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" >
+  <$set name="toc-item-class" filter="""$itemClassFilter$""" emptyValue="toc-item" value="toc-item-selected">
     <li class=<<toc-item-class>>>
       <$list filter="""[has[$field$]$field$<currentTiddler>limit[1]]""" variable="ignore" emptyMessage="<$button class='tc-btn-invisible'>{{$:/core/images/blank}}</$button> <$view field='caption'><$view field='title'/></$view>">
         <$reveal type="nomatch" state=<<toc-state>> text="open">
-          <$button set=<<toc-state>> setTo="open" class="tc-btn-invisible">
+          <$button set=<<toc-state>> setTo="open" class="tc-btn-invisible" tooltip={{!!tooltip}}>
             {{$:/core/images/right-arrow}}
             <<tocP-caption>>
           </$button>
         </$reveal>
         <$reveal type="match" state=<<toc-state>> text="open">
-          <$button set=<<toc-state>> setTo="close" class="tc-btn-invisible">
+          <$button set=<<toc-state>> setTo="close" class="tc-btn-invisible" tooltip={{!!tooltip}}>
             {{$:/core/images/down-arrow}}
             <<tocP-caption>>
           </$button> 

--- a/wikilabs/tocP/tiddlers/$__wikilabs_ui_buttons_new-child-alone.tid
+++ b/wikilabs/tocP/tiddlers/$__wikilabs_ui_buttons_new-child-alone.tid
@@ -11,7 +11,7 @@ $(currentTiddler)$
 \end
 
 \define newChildButton(field:"parent")
-<$button tooltip={{!!description}} aria-label="new child here" class=<<tv-config-toolbar-class>>>
+<$button tooltip="""New Child -> "$field$: $(currentTiddler)$" """ aria-label="new child here" class=<<tv-config-toolbar-class>>>
 <$action-sendmessage $message="tm-new-tiddler" $field$=<<newHereValue>>/>
 <$list filter="[<tv-config-toolbar-icons>prefix[yes]]">
 {{$:/wikilabs/images/new-child-alone}}

--- a/wikilabs/tocP/tiddlers/license.tid
+++ b/wikilabs/tocP/tiddlers/license.tid
@@ -1,5 +1,5 @@
 title: $:/plugins/wikilabs/tocP/license
 
-Remove-States-Plugin (c) Mario Pietsch - 2017
+Parent Based TOC Plugin (c) Mario Pietsch - 2017
 
 https://opensource.org/licenses/BSD-3-Clause

--- a/wikilabs/tocP/tiddlers/readme.tid
+++ b/wikilabs/tocP/tiddlers/readme.tid
@@ -2,6 +2,11 @@ title: $:/plugins/wikilabs/tocP/readme
 
 This plugin contains several "Table of Content" macros, that have the same parameters as the core toc macro. The main difference is, that it doesn't use tags to create the TOC scructure. It uses a "parent" field in so called "child - tiddlers".
 
+''Detailed Documentation''
+
+More details about this plugin can be found at: https://wikilabs.github.io/editions/tocP
+More plugins, themes and editions can be found at: https://wikilabs.github.io/
+
 ''Important''
 
 These macros are intended to be "drop in replacement" of the core macros. ... They have the exact same parameter names. Instead of "parent" it still uses "tag" as the first parameter. 
@@ -9,15 +14,15 @@ These macros are intended to be "drop in replacement" of the core macros. ... Th
 ''Usage''
 
 ```
-<div class="tc-table-of-contents">
+<div class="tocp tc-table-of-contents">
 <<tocP root>>
 </div>
 
-<div class="tc-table-of-contents">
+<div class="tocp tc-table-of-contents">
 <<tocP-expandable root>>
 </div>
 
-<div class="tc-table-of-contents">
+<div class="tocp tc-table-of-contents">
 <<tocP-selective-expandable root field:"any-name">>
 </div>
 
@@ -31,8 +36,12 @@ These macros are intended to be "drop in replacement" of the core macros. ... Th
 
 ```
 
-''Simple UI''
+''Simple Configuration''
 
 * Enable / Disable the inline "New Child" button
 ** {{$:/plugins/wikilabs/tocP/toggle-new-child-button}}
+
+''Known Problems''
+
 * The "tabbed" versions don't show the "New Child" buttons
+* Color customisation isn't possible atm

--- a/wikilabs/tocP/tiddlers/readme.tid
+++ b/wikilabs/tocP/tiddlers/readme.tid
@@ -4,7 +4,7 @@ This plugin contains several "Table of Content" macros, that have the same param
 
 ''Important''
 
-These macros are intended to be "drop in replacement" of the core macros. ... So they have the exact same parameter names. So instead of "parent" it still uses "tag" as the first parameter. 
+These macros are intended to be "drop in replacement" of the core macros. ... They have the exact same parameter names. Instead of "parent" it still uses "tag" as the first parameter. 
 
 ''Usage''
 
@@ -18,7 +18,7 @@ These macros are intended to be "drop in replacement" of the core macros. ... So
 </div>
 
 <div class="tc-table-of-contents">
-<<tocP-selective-expandable root>>
+<<tocP-selective-expandable root field:"any-name">>
 </div>
 
 <div class="tc-table-of-contents">


### PR DESCRIPTION
0.1.0 .. beta-1

 - improved / fixed tool button tooltips
 - fixed plugin license typo
 - new StyleSheet setting for .tocp class. It sets the default link color to green, which should set it apart from the standard toc.
    - This is probably a temporary solution, because it doesn't work for tabbed tocPs.
 - The "New Child" buttons now show a more detailed tooltip.
   - The actual "field-name: value" pair which will be used to create the new child. 
 - tocP now shows the tooltip field, if available in tiddlers. see examples or open level-1 in edit mode.